### PR TITLE
Add beta and alpha metrics to portfolio performance analysis

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -386,11 +386,19 @@ class PortfolioMetrics(BaseModel):
         Standard deviation of portfolio returns (per period).  Must be non‑negative.
     sharpe_ratio : float
         Sharpe ratio of the portfolio.
+    beta : float, optional
+        Portfolio beta relative to the benchmark (SPY).  None when no
+        benchmark data is available.
+    alpha : float, optional
+        Jensen's alpha relative to the benchmark (SPY).  None when no
+        benchmark data is available.
     """
 
     expected_return: float = Field(...)
     volatility: float = Field(..., ge=0.0)
     sharpe_ratio: float = Field(...)
+    beta: Optional[float] = Field(None, description="Portfolio beta relative to benchmark (SPY)")
+    alpha: Optional[float] = Field(None, description="Jensen's alpha relative to benchmark (SPY)")
 
 
 class CovarianceOutput(BaseModel):

--- a/server/portfolio_metrics.py
+++ b/server/portfolio_metrics.py
@@ -172,10 +172,15 @@ def build_portfolio_metrics(
         risk_free_rate=risk_free_rate,
         confidence_level=confidence_level,
     )
+    def _nan_to_none(val: Optional[float]) -> Optional[float]:
+        return None if (val is None or (isinstance(val, float) and math.isnan(val))) else val
+
     return PortfolioMetrics(
         expected_return=metrics['expected_return'],
         volatility=metrics['volatility'],
         sharpe_ratio=metrics['sharpe_ratio'],
+        beta=_nan_to_none(metrics.get('beta')),
+        alpha=_nan_to_none(metrics.get('alpha')),
     )
 
 


### PR DESCRIPTION
## Summary
This PR extends the portfolio metrics model to include beta and alpha calculations relative to a benchmark (SPY), providing additional risk and performance analysis capabilities.

## Key Changes
- **Models**: Added `beta` and `alpha` as optional fields to the `PortfolioMetrics` model with appropriate documentation
  - Both fields are optional and default to `None` when benchmark data is unavailable
  - `beta`: Portfolio beta relative to the SPY benchmark
  - `alpha`: Jensen's alpha relative to the SPY benchmark

- **Portfolio Metrics Calculation**: Updated `build_portfolio_metrics()` function to:
  - Extract `beta` and `alpha` values from the metrics calculation
  - Implement `_nan_to_none()` helper function to convert NaN values to `None` for cleaner API responses
  - Pass the converted values to the `PortfolioMetrics` constructor

## Implementation Details
- The `_nan_to_none()` helper handles both `None` values and NaN floats, ensuring robust handling of missing or invalid benchmark data
- Optional fields allow graceful degradation when benchmark data is unavailable
- The implementation maintains backward compatibility while extending the metrics output

https://claude.ai/code/session_01WUfzWRNyWFJ96EFCtNVUFe