### PR TITLE
🧹 [Code Health] Remove unused placeholder import in schemas/responses.py

### DIFF
--- a/server/app/schemas/responses.py
+++ b/server/app/schemas/responses.py
@@ -1,3 +1,1 @@
 from __future__ import annotations
-
-from . import requests  # placeholders if needed later


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused `requests` placeholder import from `server/app/schemas/responses.py`.

💡 **Why:** How this improves maintainability
Importing unused modules 'just in case' clutters the namespace and can cause linting or shadowing issues. Keeping code lean reduces cognitive load.

✅ **Verification:** How you confirmed the change is safe
Ran python syntax check via `py_compile`. Verified that no other files import `requests` from `responses.py`. Run test suite and confirm that it was failing from environment/DB setup before change and not due to this syntax change.

✨ **Result:** The improvement achieved
A cleaner schemas module namespace.

Linear Issue: SOF-18

---
*PR created automatically by Jules for task [15453614849265172438](https://jules.google.com/task/15453614849265172438) started by @chibeze01*