### PR TITLE
🔒 [security fix] Remove hardcoded default JWT_SECRET

### DIFF
--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -6,7 +6,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     DB_URL: str = Field(..., description="SQLAlchemy database URL")
-    JWT_SECRET: str = Field(default="dev-secret-change-in-production", description="Secret key for JWT signing")
+    JWT_SECRET: str = Field(..., description="Secret key for JWT signing")
     LOG_LEVEL: str = "INFO"
     ENV: str = "dev"  # dev | prod | test
     class Config:


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Removed the hardcoded default value for JWT_SECRET in `server/app/settings.py`.

⚠️ **Risk:** The potential impact if left unfixed
Having a default JWT_SECRET can lead to developers leaving it unchanged in production, which would allow attackers to forge valid JWTs and gain unauthorized access to any account.

🛡️ **Solution:** How the fix addresses the vulnerability
Made JWT_SECRET a strictly required environment variable using `Field(..., description="Secret key for JWT signing")`, which ensures the application fails to start if the administrator forgets to set a secure secret.

---
*PR created automatically by Jules for task [1020062786393004698](https://jules.google.com/task/1020062786393004698) started by @chibeze01*