### PR TITLE
⚡ Bolt: Fix N+1 queries in stock price fetching

### DIFF
--- a/server/app/domain/services/analytics_service.py
+++ b/server/app/domain/services/analytics_service.py
@@ -12,14 +12,16 @@ from ...pricing.stub_provider import get_price
 
 
 def portfolio_pnl(db: Session, user_id: str, portfolio_id: uuid.UUID) -> PnLResponse:
-    from ...pricing.yahoo_provider import get_price as yahoo_get_price
+    from ...pricing.stub_provider import get_prices_batch
 
     p = portfolio_repo.get_portfolio(db, portfolio_id)
     ensure_owner(p, user_id)
     positions: list[PnLPosition] = []
     total = Decimal("0")
+    symbols = [h.symbol for h in p.holdings]
+    prices = get_prices_batch(symbols) if symbols else {}
     for h in p.holdings:
-        price = yahoo_get_price(h.symbol) or get_price(h.symbol)
+        price = prices.get(h.symbol.upper(), get_price(h.symbol))
         unreal = (price - Decimal(str(h.average_cost))) * Decimal(str(h.quantity))
         positions.append(
             PnLPosition(
@@ -41,7 +43,8 @@ def portfolio_pnl(db: Session, user_id: str, portfolio_id: uuid.UUID) -> PnLResp
 
 def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, days: int = 30) -> HistoricalPortfolioResponse:
     """Generate historical portfolio value using real price data from Yahoo Finance."""
-    from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
+    from ...pricing.yahoo_provider import get_historical_prices
+    from ...pricing.stub_provider import get_prices_batch
 
     p = portfolio_repo.get_portfolio(db, portfolio_id)
     ensure_owner(p, user_id)
@@ -62,9 +65,12 @@ def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, day
     holding_prices = {}
     current_value = Decimal("0")
 
+    symbols = [h.symbol for h in p.holdings]
+    prices = get_prices_batch(symbols) if symbols else {}
+
     for h in p.holdings:
         history = get_historical_prices(h.symbol, days + 5)  # extra days buffer
-        current_price = yahoo_get_price(h.symbol) or get_price(h.symbol)
+        current_price = prices.get(h.symbol.upper(), get_price(h.symbol))
         current_value += current_price * Decimal(str(h.quantity))
 
         if history:

--- a/server/app/domain/services/efficient_frontier_service.py
+++ b/server/app/domain/services/efficient_frontier_service.py
@@ -10,12 +10,8 @@ from scipy.optimize import minimize
 
 from ..repositories import portfolio_repo
 from .portfolio_service import ensure_owner
-from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
-from ...pricing.stub_provider import get_price as stub_get_price
-
-
-def _get_price(symbol: str) -> Decimal:
-    return yahoo_get_price(symbol) or stub_get_price(symbol)
+from ...pricing.yahoo_provider import get_historical_prices
+from ...pricing.stub_provider import get_prices_batch, get_price as stub_get_price
 
 
 def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
@@ -71,8 +67,9 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
     # Current portfolio weights
     current_values = {}
     total_value = 0.0
+    prices = get_prices_batch(symbols) if symbols else {}
     for symbol in symbols:
-        price = float(_get_price(symbol))
+        price = float(prices.get(symbol.upper(), stub_get_price(symbol)))
         val = price * quantities[symbol]
         current_values[symbol] = val
         total_value += val

--- a/server/app/domain/services/rebalance_service.py
+++ b/server/app/domain/services/rebalance_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from ..models import RebalanceAction, RebalanceResponse
 from ..repositories import portfolio_repo
 from .portfolio_service import ensure_owner
-from ...pricing.stub_provider import get_price
+from ...pricing.stub_provider import get_price, get_prices_batch
 
 
 def compute_rebalance(db: Session, user_id: str, portfolio_id: uuid.UUID) -> RebalanceResponse:
@@ -18,8 +18,10 @@ def compute_rebalance(db: Session, user_id: str, portfolio_id: uuid.UUID) -> Reb
     # Calculate current values
     holdings_data = []
     total_value = Decimal("0")
+    symbols = [h.symbol for h in p.holdings]
+    prices = get_prices_batch(symbols) if symbols else {}
     for h in p.holdings:
-        price = get_price(h.symbol)
+        price = prices.get(h.symbol.upper(), get_price(h.symbol))
         value = price * Decimal(str(h.quantity))
         total_value += value
         holdings_data.append({

--- a/server/app/pricing/stub_provider.py
+++ b/server/app/pricing/stub_provider.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import logging
 from decimal import Decimal
+from typing import Dict
 
-from .yahoo_provider import get_price as yahoo_get_price
+from .yahoo_provider import get_price as yahoo_get_price, get_prices_batch as yahoo_get_prices_batch
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,23 @@ def get_price(symbol: str) -> Decimal:
     yahoo_price = yahoo_get_price(symbol)
     if yahoo_price is not None:
         return yahoo_price
-    
+
     # Fallback to stub
     logger.info(f"Using stub price for {symbol}")
     return _stub_price(symbol)
+
+
+def get_prices_batch(symbols: list[str]) -> Dict[str, Decimal]:
+    """
+    Get prices for multiple symbols, trying Yahoo Finance first with stub fallback.
+    """
+    yahoo_prices = yahoo_get_prices_batch(symbols)
+    results = {}
+    for symbol in symbols:
+        sym_upper = symbol.upper()
+        if yahoo_prices.get(sym_upper) is not None:
+            results[sym_upper] = yahoo_prices[sym_upper]
+        else:
+            logger.info(f"Using stub price for {symbol}")
+            results[sym_upper] = _stub_price(symbol)
+    return results

--- a/server/app/pricing/yahoo_provider.py
+++ b/server/app/pricing/yahoo_provider.py
@@ -20,40 +20,40 @@ _HISTORICAL_CACHE_TTL = timedelta(minutes=30)
 def get_price(symbol: str) -> Optional[Decimal]:
     """
     Fetch current price for a stock symbol from Yahoo Finance.
-    
+
     Returns None if unable to fetch (caller should fallback to stub).
     Results are cached for 5 minutes.
     """
     symbol = symbol.upper()
     now = datetime.now()
-    
+
     # Check cache
     if symbol in _price_cache:
         price, cached_at = _price_cache[symbol]
         if now - cached_at < _CACHE_TTL:
             return price
-    
+
     try:
         import yfinance as yf
         ticker = yf.Ticker(symbol)
         info = ticker.info
-        
+
         # Try different price fields
         price_value = (
             info.get('regularMarketPrice') or
             info.get('currentPrice') or
             info.get('previousClose')
         )
-        
+
         if price_value is None:
             logger.warning(f"No price data found for {symbol}")
             return None
-        
+
         price = Decimal(str(price_value))
         _price_cache[symbol] = (price, now)
         logger.debug(f"Fetched price for {symbol}: {price}")
         return price
-        
+
     except Exception as e:
         logger.warning(f"Failed to fetch price for {symbol}: {e}")
         return None
@@ -67,7 +67,7 @@ def get_stock_info(symbol: str) -> Optional[Dict]:
         import yfinance as yf
         ticker = yf.Ticker(symbol)
         info = ticker.info
-        
+
         return {
             'symbol': symbol.upper(),
             'name': info.get('shortName') or info.get('longName') or symbol,
@@ -85,12 +85,90 @@ def get_stock_info(symbol: str) -> Optional[Dict]:
 
 def get_prices_batch(symbols: list[str]) -> Dict[str, Optional[Decimal]]:
     """
-    Fetch prices for multiple symbols efficiently.
+    Fetch prices for multiple symbols efficiently using yf.download to avoid N+1 queries.
     """
+    if not symbols:
+        return {}
+
     result = {}
+    missing_symbols = []
+    now = datetime.now()
+
+    # Check cache first
     for symbol in symbols:
-        result[symbol.upper()] = get_price(symbol)
+        sym_upper = symbol.upper()
+        if sym_upper in _price_cache:
+            price, cached_at = _price_cache[sym_upper]
+            if now - cached_at < _CACHE_TTL:
+                result[symbol] = price
+                continue
+        missing_symbols.append(symbol)
+
+    if not missing_symbols:
+        return result
+
+    try:
+        import yfinance as yf
+        # download batch data
+        # Note: yf.download returns a DataFrame where if there's >1 symbol, columns are MultiIndex (Price, Ticker)
+        # We need the most recent close or current price
+        # Download 5 days to ensure we get a recent price (over weekends/holidays)
+        data = yf.download(missing_symbols, period="5d", progress=False)
+
+        if data.empty:
+            logger.warning(f"No price data found for batch {missing_symbols}")
+            for s in missing_symbols:
+                result[s] = None
+            return result
+
+        # Get the latest row which has the most recent prices
+        # Use ffill to carry forward previous close if latest is NaN
+        data_ffill = data.ffill()
+        latest = data_ffill.iloc[-1]
+
+        if len(missing_symbols) == 1:
+            # Single symbol returns a simple index
+            sym = missing_symbols[0]
+            sym_upper = sym.upper()
+            price_val = latest.get("Close")
+            if price_val is not None and not import_math_isnan(price_val):
+                price = Decimal(str(round(price_val, 2)))
+                _price_cache[sym_upper] = (price, now)
+                result[sym] = price
+            else:
+                result[sym] = None
+        else:
+            # Multiple symbols return a MultiIndex (Price, Ticker)
+            closes = data_ffill['Close'].iloc[-1]
+            for sym in missing_symbols:
+                sym_upper = sym.upper()
+                try:
+                    price_val = closes[sym_upper]
+                    if price_val is not None and not import_math_isnan(price_val):
+                        price = Decimal(str(round(price_val, 2)))
+                        _price_cache[sym_upper] = (price, now)
+                        result[sym] = price
+                    else:
+                        result[sym] = None
+                except Exception:
+                    result[sym] = None
+
+    except Exception as e:
+        logger.warning(f"Failed to fetch batch prices for {missing_symbols}: {e}")
+        for s in missing_symbols:
+            # Fall back to individual fetching just in case batch failed completely
+            # but yf.Ticker still works (rare, but possible)
+            result[s] = get_price(s)
+
     return result
+
+
+def import_math_isnan(val):
+    import math
+    try:
+        return math.isnan(float(val))
+    except Exception:
+        return True
 
 
 def get_historical_prices(symbol: str, days: int = 30) -> Optional[list[dict]]:


### PR DESCRIPTION
💡 What: Replaced sequential `get_price` calls in loops with a single `get_prices_batch` call. Uses `yfinance.download` to fetch all prices in one go.
🎯 Why: Fixes an N+1 query problem that slowed down portfolio endpoints (especially rebalance, analytics, and efficient frontier) for portfolios with many holdings.
📊 Impact: Reduces external API calls from O(N) to O(1) where N is the number of unique holdings in a portfolio. For a portfolio with 20 holdings, this saves 19 network calls per request, significantly decreasing latency.
🔬 Measurement: Verify by creating a portfolio with many unique holdings and loading the rebalance or PnL endpoints. Observe server logs for reduced Yahoo Finance fetches.

---
*PR created automatically by Jules for task [16071747560599441141](https://jules.google.com/task/16071747560599441141) started by @chibeze01*