### PR TITLE
⚡ Bolt: [performance improvement] Batch yfinance price fetches

### DIFF
--- a/server/app/domain/services/analytics_service.py
+++ b/server/app/domain/services/analytics_service.py
@@ -12,14 +12,19 @@ from ...pricing.stub_provider import get_price
 
 
 def portfolio_pnl(db: Session, user_id: str, portfolio_id: uuid.UUID) -> PnLResponse:
-    from ...pricing.yahoo_provider import get_price as yahoo_get_price
+    from ...pricing.yahoo_provider import get_prices_batch as yahoo_get_prices_batch
 
     p = portfolio_repo.get_portfolio(db, portfolio_id)
     ensure_owner(p, user_id)
     positions: list[PnLPosition] = []
     total = Decimal("0")
+
+    # Pre-fetch all prices in a single batch to avoid N+1 bottleneck
+    symbols = [h.symbol for h in p.holdings]
+    batch_prices = yahoo_get_prices_batch(symbols) if symbols else {}
+
     for h in p.holdings:
-        price = yahoo_get_price(h.symbol) or get_price(h.symbol)
+        price = batch_prices.get(h.symbol.upper()) or get_price(h.symbol)
         unreal = (price - Decimal(str(h.average_cost))) * Decimal(str(h.quantity))
         positions.append(
             PnLPosition(
@@ -41,7 +46,7 @@ def portfolio_pnl(db: Session, user_id: str, portfolio_id: uuid.UUID) -> PnLResp
 
 def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, days: int = 30) -> HistoricalPortfolioResponse:
     """Generate historical portfolio value using real price data from Yahoo Finance."""
-    from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
+    from ...pricing.yahoo_provider import get_historical_prices, get_prices_batch as yahoo_get_prices_batch
 
     p = portfolio_repo.get_portfolio(db, portfolio_id)
     ensure_owner(p, user_id)
@@ -58,13 +63,17 @@ def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, day
             current_value=Decimal("0"),
         )
 
+    # Pre-fetch all current prices in a single batch to avoid N+1 bottleneck
+    symbols = [h.symbol for h in p.holdings]
+    batch_prices = yahoo_get_prices_batch(symbols) if symbols else {}
+
     # Fetch historical prices for each holding
     holding_prices = {}
     current_value = Decimal("0")
 
     for h in p.holdings:
         history = get_historical_prices(h.symbol, days + 5)  # extra days buffer
-        current_price = yahoo_get_price(h.symbol) or get_price(h.symbol)
+        current_price = batch_prices.get(h.symbol.upper()) or get_price(h.symbol)
         current_value += current_price * Decimal(str(h.quantity))
 
         if history:

--- a/server/app/pricing/yahoo_provider.py
+++ b/server/app/pricing/yahoo_provider.py
@@ -20,40 +20,40 @@ _HISTORICAL_CACHE_TTL = timedelta(minutes=30)
 def get_price(symbol: str) -> Optional[Decimal]:
     """
     Fetch current price for a stock symbol from Yahoo Finance.
-    
+
     Returns None if unable to fetch (caller should fallback to stub).
     Results are cached for 5 minutes.
     """
     symbol = symbol.upper()
     now = datetime.now()
-    
+
     # Check cache
     if symbol in _price_cache:
         price, cached_at = _price_cache[symbol]
         if now - cached_at < _CACHE_TTL:
             return price
-    
+
     try:
         import yfinance as yf
         ticker = yf.Ticker(symbol)
         info = ticker.info
-        
+
         # Try different price fields
         price_value = (
             info.get('regularMarketPrice') or
             info.get('currentPrice') or
             info.get('previousClose')
         )
-        
+
         if price_value is None:
             logger.warning(f"No price data found for {symbol}")
             return None
-        
+
         price = Decimal(str(price_value))
         _price_cache[symbol] = (price, now)
         logger.debug(f"Fetched price for {symbol}: {price}")
         return price
-        
+
     except Exception as e:
         logger.warning(f"Failed to fetch price for {symbol}: {e}")
         return None
@@ -67,7 +67,7 @@ def get_stock_info(symbol: str) -> Optional[Dict]:
         import yfinance as yf
         ticker = yf.Ticker(symbol)
         info = ticker.info
-        
+
         return {
             'symbol': symbol.upper(),
             'name': info.get('shortName') or info.get('longName') or symbol,
@@ -85,11 +85,67 @@ def get_stock_info(symbol: str) -> Optional[Dict]:
 
 def get_prices_batch(symbols: list[str]) -> Dict[str, Optional[Decimal]]:
     """
-    Fetch prices for multiple symbols efficiently.
+    Fetch prices for multiple symbols efficiently using a single yfinance request.
+    This prevents N+1 bottlenecks when evaluating portfolios with multiple holdings.
     """
-    result = {}
+    result = {symbol.upper(): None for symbol in symbols}
+    if not symbols:
+        return result
+
+    symbols_to_fetch = []
+    now = datetime.now()
+
+    # Check cache first
     for symbol in symbols:
-        result[symbol.upper()] = get_price(symbol)
+        sym_upper = symbol.upper()
+        if sym_upper in _price_cache:
+            price, cached_at = _price_cache[sym_upper]
+            if now - cached_at < _CACHE_TTL:
+                result[sym_upper] = price
+                continue
+        symbols_to_fetch.append(sym_upper)
+
+    if not symbols_to_fetch:
+        return result
+
+    try:
+        import yfinance as yf
+        # Fetch remaining symbols in one batch request
+        data = yf.download(symbols_to_fetch, period="1d", progress=False)
+
+        if 'Close' in data.columns:
+            close_data = data['Close']
+
+            # yfinance returns a DataFrame with symbols as columns for multiple tickers,
+            # but a Series for a single ticker.
+            if hasattr(close_data, 'columns'):
+                for symbol in symbols_to_fetch:
+                    if symbol in close_data.columns and not close_data[symbol].dropna().empty:
+                        val = close_data[symbol].dropna().iloc[-1]
+                        price = Decimal(str(val))
+                        result[symbol] = price
+                        _price_cache[symbol] = (price, now)
+                        logger.debug(f"Fetched batch price for {symbol}: {price}")
+                    else:
+                        logger.warning(f"No batch price data found for {symbol}")
+            else:
+                # Single ticker fallback
+                if not close_data.dropna().empty:
+                    val = close_data.dropna().iloc[-1]
+                    price = Decimal(str(val))
+                    symbol = symbols_to_fetch[0]
+                    result[symbol] = price
+                    _price_cache[symbol] = (price, now)
+                    logger.debug(f"Fetched batch price for {symbol}: {price}")
+                else:
+                    logger.warning(f"No batch price data found for {symbols_to_fetch[0]}")
+
+    except Exception as e:
+        logger.warning(f"Failed to fetch batch prices: {e}")
+        # Fallback to individual fetching if batch fails
+        for symbol in symbols_to_fetch:
+            result[symbol] = get_price(symbol)
+
     return result
 
 


### PR DESCRIPTION
💡 What: The `get_prices_batch` function in `yahoo_provider.py` now uses `yfinance.download(symbols)` to batch fetch multiple symbol prices in a single API call instead of iterating and making N+1 individual requests. The `portfolio_pnl` and `portfolio_historical` endpoints in `analytics_service.py` have been updated to pre-fetch these prices at the top level before their holdings loops.

🎯 Why: To solve the N+1 query problem when loading portfolios with multiple holdings. Previously, checking the price for a 50-holding portfolio resulted in 50 distinct requests to Yahoo Finance, creating massive bottlenecks.

📊 Impact: Significantly reduces network load and speeds up analytics performance for multi-holding portfolios (e.g., changes an O(N) network requests to O(1)).

🔬 Measurement: Observe the time taken to hit the `/api/v1/analytics/pnl` or `/api/v1/analytics/historical` endpoints for a portfolio with a large number of holdings (e.g., > 10). It should be consistently faster compared to individual fetches.

---
*PR created automatically by Jules for task [10087228686483759555](https://jules.google.com/task/10087228686483759555) started by @chibeze01*