### PR TITLE
⚡ Bolt: Batch fetch historical prices to prevent N+1 bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-28 - [Backend Yahoo Finance Bulk Download]
 **Learning:** The application was experiencing an N+1 problem in `analytics_service` and `rebalance_service` because `get_price(h.symbol)` was called in a loop for each holding in a portfolio, triggering individual HTTP requests to Yahoo Finance for every ticker. This was not ideal and caused serious performance bottlenecks when calculating portfolio summaries.
 **Action:** Implemented `get_prices_batch` in `server/app/pricing/yahoo_provider.py` using `yfinance.download(symbols_string, period="1d")` to batch requests. Replaced individual fetches in domain services with upfront bulk fetches. When optimizing similar pricing operations, always check if bulk retrieval capabilities exist for the upstream API/provider.
+
+## 2024-04-12 - [Backend Historical Pricing N+1 Optimization]
+**Learning:** The `efficient_frontier_service` was experiencing an N+1 performance bottleneck similar to the current pricing fetch issue, by calling `get_historical_prices(symbol)` individually for each holding in a loop to compute the efficient frontier.
+**Action:** Implemented `get_historical_prices_batch` in `server/app/pricing/yahoo_provider.py` to parallelize fetches using `ThreadPoolExecutor`. Moving forward, always ensure that repetitive upstream network calls inside loops are converted into upfront batch requests, both for current and historical market data.

--- a/server/app/domain/services/efficient_frontier_service.py
+++ b/server/app/domain/services/efficient_frontier_service.py
@@ -10,7 +10,7 @@ from scipy.optimize import minimize
 
 from ..repositories import portfolio_repo
 from .portfolio_service import ensure_owner
-from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
+from ...pricing.yahoo_provider import get_historical_prices_batch, get_price as yahoo_get_price
 from ...pricing.stub_provider import get_price as stub_get_price
 
 
@@ -40,8 +40,10 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
 
     # Fetch historical prices (365 days ≈ 252 trading days for stable estimates)
     returns_matrix = []
+    historical_prices_batch = get_historical_prices_batch(symbols, 365)
+
     for symbol in symbols:
-        history = get_historical_prices(symbol, 365)
+        history = historical_prices_batch.get(symbol.upper())
         if not history or len(history) < 60:
             raise HTTPException(
                 status_code=400,

--- a/server/app/pricing/yahoo_provider.py
+++ b/server/app/pricing/yahoo_provider.py
@@ -109,6 +109,29 @@ def get_prices_batch(symbols: list[str]) -> Dict[str, Optional[Decimal]]:
     return result
 
 
+def get_historical_prices_batch(symbols: list[str], days: int = 30) -> Dict[str, Optional[list[dict]]]:
+    """
+    Fetch historical prices for multiple symbols efficiently using a thread pool.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    result = {}
+    unique_symbols = list(set(symbols))
+    if not unique_symbols:
+        return result
+
+    with ThreadPoolExecutor(max_workers=min(10, len(unique_symbols))) as executor:
+        future_to_sym = {executor.submit(get_historical_prices, sym, days): sym.upper() for sym in unique_symbols}
+        for future in future_to_sym:
+            sym = future_to_sym[future]
+            try:
+                result[sym] = future.result()
+            except Exception as e:
+                logger.warning(f"Failed to fetch batch historical prices for {sym}: {e}")
+                result[sym] = None
+
+    return result
+
 def get_historical_prices(symbol: str, days: int = 30) -> Optional[list[dict]]:
     """
     Fetch historical closing prices for a symbol from Yahoo Finance.


### PR DESCRIPTION
💡 What: Added `get_historical_prices_batch` using `ThreadPoolExecutor` and updated `efficient_frontier_service` to fetch historical prices upfront instead of in a loop.
🎯 Why: Prevents N+1 network calls when generating the efficient frontier, drastically speeding up requests for portfolios with many holdings.
📊 Impact: Portfolio efficient frontier generation is now bounded by the longest individual request (in parallel), avoiding linear scaling delays (reduces historical price fetch time by up to ~90% for large portfolios).
🔬 Measurement: Backend tests passed, verifying the new flow preserves identical functionality.

---
*PR created automatically by Jules for task [1895708311913732132](https://jules.google.com/task/1895708311913732132) started by @chibeze01*