### PR TITLE
⚡ Bolt: Batch network calls for historical prices

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-03-28 - [Backend Yahoo Finance Bulk Download]
 **Learning:** The application was experiencing an N+1 problem in `analytics_service` and `rebalance_service` because `get_price(h.symbol)` was called in a loop for each holding in a portfolio, triggering individual HTTP requests to Yahoo Finance for every ticker. This was not ideal and caused serious performance bottlenecks when calculating portfolio summaries.
 **Action:** Implemented `get_prices_batch` in `server/app/pricing/yahoo_provider.py` using `yfinance.download(symbols_string, period="1d")` to batch requests. Replaced individual fetches in domain services with upfront bulk fetches. When optimizing similar pricing operations, always check if bulk retrieval capabilities exist for the upstream API/provider.
+## 2024-10-24 - Batch Network Calls for Yahoo Finance
+**Learning:** Sequential network calls to external APIs like Yahoo Finance inside loops (N+1 queries) are a major performance bottleneck for domain services calculating portfolio metrics.
+**Action:** Always implement and use batched versions of API fetching functions (e.g., `get_historical_prices_batch`) that use `ThreadPoolExecutor` to parallelize requests, pre-fetching the necessary data before entering processing loops.

--- a/server/app/domain/services/analytics_service.py
+++ b/server/app/domain/services/analytics_service.py
@@ -46,7 +46,7 @@ def portfolio_pnl(db: Session, user_id: str, portfolio_id: uuid.UUID) -> PnLResp
 
 def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, days: int = 30) -> HistoricalPortfolioResponse:
     """Generate historical portfolio value using real price data from Yahoo Finance."""
-    from ...pricing.yahoo_provider import get_historical_prices, get_prices_batch as yahoo_get_prices_batch
+    from ...pricing.yahoo_provider import get_historical_prices_batch, get_prices_batch as yahoo_get_prices_batch
 
     p = portfolio_repo.get_portfolio(db, portfolio_id)
     ensure_owner(p, user_id)
@@ -67,12 +67,15 @@ def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, day
     symbols = [h.symbol for h in p.holdings]
     batched_prices = yahoo_get_prices_batch(symbols)
 
+    # Pre-fetch historical prices in batch
+    batched_history = get_historical_prices_batch(symbols, days + 5) # extra days buffer
+
     # Fetch historical prices for each holding
     holding_prices = {}
     current_value = Decimal("0")
 
     for h in p.holdings:
-        history = get_historical_prices(h.symbol, days + 5)  # extra days buffer
+        history = batched_history.get(h.symbol.upper())
         current_price = batched_prices.get(h.symbol) or get_price(h.symbol)
         current_value += current_price * Decimal(str(h.quantity))
 

--- a/server/app/domain/services/efficient_frontier_service.py
+++ b/server/app/domain/services/efficient_frontier_service.py
@@ -10,12 +10,8 @@ from scipy.optimize import minimize
 
 from ..repositories import portfolio_repo
 from .portfolio_service import ensure_owner
-from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
+from ...pricing.yahoo_provider import get_historical_prices_batch, get_prices_batch as yahoo_get_prices_batch
 from ...pricing.stub_provider import get_price as stub_get_price
-
-
-def _get_price(symbol: str) -> Decimal:
-    return yahoo_get_price(symbol) or stub_get_price(symbol)
 
 
 def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
@@ -40,8 +36,10 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
 
     # Fetch historical prices (365 days ≈ 252 trading days for stable estimates)
     returns_matrix = []
+    batched_history = get_historical_prices_batch(symbols, 365)
+
     for symbol in symbols:
-        history = get_historical_prices(symbol, 365)
+        history = batched_history.get(symbol.upper())
         if not history or len(history) < 60:
             raise HTTPException(
                 status_code=400,
@@ -71,8 +69,11 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
     # Current portfolio weights
     current_values = {}
     total_value = 0.0
+    batched_prices = yahoo_get_prices_batch(symbols) if symbols else {}
+
     for symbol in symbols:
-        price = float(_get_price(symbol))
+        raw_price = batched_prices.get(symbol.upper()) or stub_get_price(symbol)
+        price = float(raw_price)
         val = price * quantities[symbol]
         current_values[symbol] = val
         total_value += val

--- a/server/app/pricing/yahoo_provider.py
+++ b/server/app/pricing/yahoo_provider.py
@@ -151,6 +151,30 @@ def get_historical_prices(symbol: str, days: int = 30) -> Optional[list[dict]]:
         return None
 
 
+def get_historical_prices_batch(symbols: list[str], days: int = 30) -> dict[str, Optional[list[dict]]]:
+    """
+    Fetch historical prices for multiple symbols efficiently using a thread pool.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    result = {}
+    unique_symbols = list(set(symbols))
+    if not unique_symbols:
+        return result
+
+    with ThreadPoolExecutor(max_workers=min(10, len(unique_symbols))) as executor:
+        future_to_sym = {executor.submit(get_historical_prices, sym, days): sym.upper() for sym in unique_symbols}
+        for future in future_to_sym:
+            sym = future_to_sym[future]
+            try:
+                result[sym] = future.result()
+            except Exception as e:
+                logger.warning(f"Failed to fetch batch historical prices for {sym}: {e}")
+                result[sym] = None
+
+    return result
+
+
 def clear_cache():
     """Clear the price and historical caches."""
     global _price_cache, _historical_cache


### PR DESCRIPTION
💡 What: Added `get_historical_prices_batch` to `yahoo_provider.py` which uses a `ThreadPoolExecutor` to fetch prices in parallel. Refactored `analytics_service.py` and `efficient_frontier_service.py` to use this new batched fetcher instead of calling `get_historical_prices` inside loops.
🎯 Why: Calling `get_historical_prices` (and `get_price`) individually inside a loop across all holdings creates an N+1 query bottleneck, causing long request durations directly proportional to the number of holdings.
📊 Impact: Expected to significantly reduce latency on historical portfolio value generation and efficient frontier calculations by parallelizing network calls to the pricing provider.
🔬 Measurement: Verify by measuring latency of the `/api/portfolios/{id}/historical` and `/api/portfolios/{id}/efficient-frontier` endpoints before and after the change on portfolios with multiple holdings.

---
*PR created automatically by Jules for task [12274808036266964530](https://jules.google.com/task/12274808036266964530) started by @chibeze01*