### PR TITLE
⚡ Bolt: [Batch fetch historical prices]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-28 - [Backend Yahoo Finance Bulk Download]
 **Learning:** The application was experiencing an N+1 problem in `analytics_service` and `rebalance_service` because `get_price(h.symbol)` was called in a loop for each holding in a portfolio, triggering individual HTTP requests to Yahoo Finance for every ticker. This was not ideal and caused serious performance bottlenecks when calculating portfolio summaries.
 **Action:** Implemented `get_prices_batch` in `server/app/pricing/yahoo_provider.py` using `yfinance.download(symbols_string, period="1d")` to batch requests. Replaced individual fetches in domain services with upfront bulk fetches. When optimizing similar pricing operations, always check if bulk retrieval capabilities exist for the upstream API/provider.
+
+## 2024-06-25 - [Backend Historical Prices Bulk Fetch]
+**Learning:** `analytics_service` and `efficient_frontier_service` suffered from an N+1 performance bottleneck when fetching historical prices for portfolio holdings. `get_historical_prices(symbol)` was being called sequentially for each symbol, making the API very slow for large portfolios.
+**Action:** Implemented `get_historical_prices_batch` in `server/app/pricing/yahoo_provider.py` to concurrently fetch historical prices using a `ThreadPoolExecutor`. Replaced sequential fetches with batch fetches in domain services, significantly reducing response latency.

--- a/server/app/domain/services/analytics_service.py
+++ b/server/app/domain/services/analytics_service.py
@@ -46,7 +46,7 @@ def portfolio_pnl(db: Session, user_id: str, portfolio_id: uuid.UUID) -> PnLResp
 
 def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, days: int = 30) -> HistoricalPortfolioResponse:
     """Generate historical portfolio value using real price data from Yahoo Finance."""
-    from ...pricing.yahoo_provider import get_historical_prices, get_prices_batch as yahoo_get_prices_batch
+    from ...pricing.yahoo_provider import get_historical_prices_batch, get_prices_batch as yahoo_get_prices_batch
 
     p = portfolio_repo.get_portfolio(db, portfolio_id)
     ensure_owner(p, user_id)
@@ -71,8 +71,10 @@ def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, day
     holding_prices = {}
     current_value = Decimal("0")
 
+    batched_histories = get_historical_prices_batch(symbols, days + 5)  # extra days buffer
+
     for h in p.holdings:
-        history = get_historical_prices(h.symbol, days + 5)  # extra days buffer
+        history = batched_histories.get(h.symbol.upper())
         current_price = batched_prices.get(h.symbol) or get_price(h.symbol)
         current_value += current_price * Decimal(str(h.quantity))
 

--- a/server/app/domain/services/efficient_frontier_service.py
+++ b/server/app/domain/services/efficient_frontier_service.py
@@ -10,7 +10,7 @@ from scipy.optimize import minimize
 
 from ..repositories import portfolio_repo
 from .portfolio_service import ensure_owner
-from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
+from ...pricing.yahoo_provider import get_historical_prices, get_historical_prices_batch, get_price as yahoo_get_price
 from ...pricing.stub_provider import get_price as stub_get_price
 
 
@@ -40,8 +40,9 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
 
     # Fetch historical prices (365 days ≈ 252 trading days for stable estimates)
     returns_matrix = []
+    batched_histories = get_historical_prices_batch(symbols, 365)
     for symbol in symbols:
-        history = get_historical_prices(symbol, 365)
+        history = batched_histories.get(symbol.upper())
         if not history or len(history) < 60:
             raise HTTPException(
                 status_code=400,

--- a/server/app/pricing/yahoo_provider.py
+++ b/server/app/pricing/yahoo_provider.py
@@ -109,6 +109,30 @@ def get_prices_batch(symbols: list[str]) -> Dict[str, Optional[Decimal]]:
     return result
 
 
+def get_historical_prices_batch(symbols: list[str], days: int = 30) -> Dict[str, Optional[list[dict]]]:
+    """
+    Fetch historical closing prices for multiple symbols efficiently using a thread pool.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    result = {}
+    unique_symbols = list(set(symbols))
+    if not unique_symbols:
+        return result
+
+    with ThreadPoolExecutor(max_workers=min(10, len(unique_symbols))) as executor:
+        future_to_sym = {executor.submit(get_historical_prices, sym, days): sym.upper() for sym in unique_symbols}
+        for future in future_to_sym:
+            sym = future_to_sym[future]
+            try:
+                result[sym] = future.result()
+            except Exception as e:
+                logger.warning(f"Failed to fetch batch historical price for {sym}: {e}")
+                result[sym] = None
+
+    return result
+
+
 def get_historical_prices(symbol: str, days: int = 30) -> Optional[list[dict]]:
     """
     Fetch historical closing prices for a symbol from Yahoo Finance.


### PR DESCRIPTION
💡 What: Implemented `get_historical_prices_batch` in `yahoo_provider.py` which uses a thread pool to fetch historical prices concurrently for multiple symbols. Replaced the sequential `get_historical_prices` loop in `analytics_service.py` and `efficient_frontier_service.py` with this batch approach.
🎯 Why: The application suffered from an N+1 performance bottleneck in services relying on historical data, where `get_historical_prices` was called repeatedly for each holding in a portfolio. This was slow and blocked the main thread for large portfolios.
📊 Impact: Significantly reduces latency for portfolio historical charts and efficient frontier calculations by parallelizing API calls to Yahoo Finance.
🔬 Measurement: Verify by loading historical charts or running efficient frontier calculations for large portfolios; time taken should now be mostly bottlenecked by the slowest single request, rather than the sum of all requests.

---
*PR created automatically by Jules for task [12478458717784151650](https://jules.google.com/task/12478458717784151650) started by @chibeze01*