### PR TITLE
⚡ Bolt: Batch pricing requests to solve N+1 bottleneck

### DIFF
--- a/server/app/domain/services/analytics_service.py
+++ b/server/app/domain/services/analytics_service.py
@@ -46,7 +46,7 @@ def portfolio_pnl(db: Session, user_id: str, portfolio_id: uuid.UUID) -> PnLResp
 
 def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, days: int = 30) -> HistoricalPortfolioResponse:
     """Generate historical portfolio value using real price data from Yahoo Finance."""
-    from ...pricing.yahoo_provider import get_historical_prices, get_prices_batch as yahoo_get_prices_batch
+    from ...pricing.yahoo_provider import get_historical_prices, get_prices_batch as yahoo_get_prices_batch, get_historical_prices_batch
 
     p = portfolio_repo.get_portfolio(db, portfolio_id)
     ensure_owner(p, user_id)
@@ -67,12 +67,15 @@ def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, day
     symbols = [h.symbol for h in p.holdings]
     batched_prices = yahoo_get_prices_batch(symbols)
 
+    # Pre-fetch historical prices in batch
+    batched_historical = get_historical_prices_batch(symbols, days + 5)
+
     # Fetch historical prices for each holding
     holding_prices = {}
     current_value = Decimal("0")
 
     for h in p.holdings:
-        history = get_historical_prices(h.symbol, days + 5)  # extra days buffer
+        history = batched_historical.get(h.symbol.upper())
         current_price = batched_prices.get(h.symbol) or get_price(h.symbol)
         current_value += current_price * Decimal(str(h.quantity))
 

--- a/server/app/domain/services/efficient_frontier_service.py
+++ b/server/app/domain/services/efficient_frontier_service.py
@@ -10,7 +10,7 @@ from scipy.optimize import minimize
 
 from ..repositories import portfolio_repo
 from .portfolio_service import ensure_owner
-from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
+from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price, get_prices_batch, get_historical_prices_batch
 from ...pricing.stub_provider import get_price as stub_get_price
 
 
@@ -38,10 +38,14 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
     quantities = {h.symbol: float(h.quantity) for h in p.holdings}
     n = len(symbols)
 
+    # Pre-fetch historical and current prices in batch
+    batched_historical = get_historical_prices_batch(symbols, 365)
+    batched_prices = get_prices_batch(symbols)
+
     # Fetch historical prices (365 days ≈ 252 trading days for stable estimates)
     returns_matrix = []
     for symbol in symbols:
-        history = get_historical_prices(symbol, 365)
+        history = batched_historical.get(symbol.upper())
         if not history or len(history) < 60:
             raise HTTPException(
                 status_code=400,
@@ -72,7 +76,10 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
     current_values = {}
     total_value = 0.0
     for symbol in symbols:
-        price = float(_get_price(symbol))
+        price_val = batched_prices.get(symbol.upper())
+        if price_val is None:
+             price_val = stub_get_price(symbol)
+        price = float(price_val)
         val = price * quantities[symbol]
         current_values[symbol] = val
         total_value += val

--- a/server/app/pricing/yahoo_provider.py
+++ b/server/app/pricing/yahoo_provider.py
@@ -109,6 +109,30 @@ def get_prices_batch(symbols: list[str]) -> Dict[str, Optional[Decimal]]:
     return result
 
 
+def get_historical_prices_batch(symbols: list[str], days: int = 30) -> Dict[str, Optional[list[dict]]]:
+    """
+    Fetch historical prices for multiple symbols efficiently using a thread pool.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    result = {}
+    unique_symbols = list(set(symbols))
+    if not unique_symbols:
+        return result
+
+    with ThreadPoolExecutor(max_workers=min(10, len(unique_symbols))) as executor:
+        future_to_sym = {executor.submit(get_historical_prices, sym, days): sym.upper() for sym in unique_symbols}
+        for future in future_to_sym:
+            sym = future_to_sym[future]
+            try:
+                result[sym] = future.result()
+            except Exception as e:
+                logger.warning(f"Failed to fetch batch historical prices for {sym}: {e}")
+                result[sym] = None
+
+    return result
+
+
 def get_historical_prices(symbol: str, days: int = 30) -> Optional[list[dict]]:
     """
     Fetch historical closing prices for a symbol from Yahoo Finance.


### PR DESCRIPTION
💡 What: Added `get_historical_prices_batch` in `yahoo_provider.py` to fetch historical prices for multiple symbols concurrently using `ThreadPoolExecutor`. Updated `analytics_service.py` and `efficient_frontier_service.py` to use this batch method instead of fetching historical prices individually in loops over holdings.
🎯 Why: The application suffered from an N+1 performance bottleneck when calculating portfolio summaries (specifically historical values and efficient frontiers). Fetching historical prices one by one in a loop caused severe performance issues, especially for portfolios with many holdings.
📊 Impact: Significantly speeds up historical portfolio analysis and efficient frontier calculations by parallelizing network requests to Yahoo Finance. Reduces the number of blocking HTTP calls from N (number of holdings) to roughly N/10 (assuming max 10 workers).
🔬 Measurement: Verify by computing the efficient frontier or historical performance of a portfolio with many holdings; the response time should be drastically lower.

---
*PR created automatically by Jules for task [4017022142316892157](https://jules.google.com/task/4017022142316892157) started by @chibeze01*