### PR TITLE
⚡ Bolt: Fix N+1 sequential price lookups in efficient frontier service

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-28 - [Backend Yahoo Finance Bulk Download]
 **Learning:** The application was experiencing an N+1 problem in `analytics_service` and `rebalance_service` because `get_price(h.symbol)` was called in a loop for each holding in a portfolio, triggering individual HTTP requests to Yahoo Finance for every ticker. This was not ideal and caused serious performance bottlenecks when calculating portfolio summaries.
 **Action:** Implemented `get_prices_batch` in `server/app/pricing/yahoo_provider.py` using `yfinance.download(symbols_string, period="1d")` to batch requests. Replaced individual fetches in domain services with upfront bulk fetches. When optimizing similar pricing operations, always check if bulk retrieval capabilities exist for the upstream API/provider.
+
+## 2026-04-19 - Avoid N+1 sequential price lookups in domain services
+**Learning:** Sequential price lookups in loops (like `efficient_frontier_service.py` checking prices for each holding) create significant performance bottlenecks due to N+1 API calls/computations. The codebase has a batch price fetching function (`yahoo_provider.get_prices_batch`) designed to solve this.
+**Action:** When working with multiple symbols, pre-fetch prices before loops using `yahoo_get_prices_batch`, and use `.get(symbol.upper())` within the loop, while maintaining the fallback to `_get_price(symbol)` to preserve robustness. Always uppercase symbols when looking them up from the batch response.

--- a/server/app/domain/services/efficient_frontier_service.py
+++ b/server/app/domain/services/efficient_frontier_service.py
@@ -68,11 +68,21 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
     expected_returns = (1 + mean_daily) ** trading_days - 1
     cov_matrix = cov_daily * trading_days
 
+    from ...pricing.yahoo_provider import get_prices_batch as yahoo_get_prices_batch
+
+    # Pre-fetch current prices in batch to prevent N+1 sequential lookups bottleneck
+    batched_prices = yahoo_get_prices_batch(symbols) if symbols else {}
+
     # Current portfolio weights
     current_values = {}
     total_value = 0.0
     for symbol in symbols:
-        price = float(_get_price(symbol))
+        # Use batched prices first, then fallback to _get_price to preserve existing fallback chain
+        price_val = batched_prices.get(symbol.upper())
+        if price_val is None:
+            price_val = _get_price(symbol)
+
+        price = float(price_val)
         val = price * quantities[symbol]
         current_values[symbol] = val
         total_value += val


### PR DESCRIPTION
💡 **What:** Replaced the sequential, individual price lookups in `efficient_frontier_service.py::_load_portfolio_data` with a single batch fetch using `yahoo_provider.get_prices_batch`.
🎯 **Why:** To prevent an N+1 performance bottleneck. When loading a portfolio with many holdings, fetching prices individually creates unnecessary latency through multiple network/computation requests.
📊 **Impact:** Significantly reduces time spent loading portfolio data for the efficient frontier feature, as N price fetches are now consolidated into 1 batch fetch.
🔬 **Measurement:** Verify the improvement by rendering the Efficient Frontier for a large portfolio; it will load substantially faster. Backend tests confirm no functionality/fallback logic was broken.

---
*PR created automatically by Jules for task [12408407298648796139](https://jules.google.com/task/12408407298648796139) started by @chibeze01*