### PR TITLE
⚡ Bolt: [efficient frontier batch fetching]

### DIFF
--- a/server/app/domain/services/efficient_frontier_service.py
+++ b/server/app/domain/services/efficient_frontier_service.py
@@ -10,12 +10,23 @@ from scipy.optimize import minimize
 
 from ..repositories import portfolio_repo
 from .portfolio_service import ensure_owner
-from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
+from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price, get_prices_batch as yahoo_get_prices_batch
 from ...pricing.stub_provider import get_price as stub_get_price
 
 
 def _get_price(symbol: str) -> Decimal:
     return yahoo_get_price(symbol) or stub_get_price(symbol)
+
+def _get_prices_batch(symbols: list[str]) -> dict[str, Decimal]:
+    """Fetch prices in bulk and fallback to stub only if needed."""
+    batched_prices = yahoo_get_prices_batch(symbols)
+    results = {}
+    for symbol in symbols:
+        price = batched_prices.get(symbol.upper())
+        if price is None:
+            price = stub_get_price(symbol)
+        results[symbol] = price
+    return results
 
 
 def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
@@ -71,8 +82,12 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
     # Current portfolio weights
     current_values = {}
     total_value = 0.0
+
+    # ⚡ Bolt: Batch fetch all current prices to avoid N+1 requests
+    current_prices = _get_prices_batch(symbols)
+
     for symbol in symbols:
-        price = float(_get_price(symbol))
+        price = float(current_prices[symbol])
         val = price * quantities[symbol]
         current_values[symbol] = val
         total_value += val


### PR DESCRIPTION
💡 What: Implemented `_get_prices_batch` in `efficient_frontier_service.py` to fetch current holding prices via `yahoo_get_prices_batch` and fallback correctly to stubs.
🎯 Why: The original implementation in `_load_portfolio_data` iterated over holdings and fetched current prices synchronously, causing an O(N) network bottleneck for Yahoo Finance price retrieval.
📊 Impact: Consolidates network requests into 1 batch request, drastically reducing loading time when calculating the efficient frontier for portfolios with many assets.
🔬 Measurement: Verify with `pytest tests/test_efficient_frontier.py`.

---
*PR created automatically by Jules for task [12431075883061849674](https://jules.google.com/task/12431075883061849674) started by @chibeze01*