### PR TITLE
⚡ Bolt: Fix N+1 price fetching in efficient frontier

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-28 - [Backend Yahoo Finance Bulk Download]
 **Learning:** The application was experiencing an N+1 problem in `analytics_service` and `rebalance_service` because `get_price(h.symbol)` was called in a loop for each holding in a portfolio, triggering individual HTTP requests to Yahoo Finance for every ticker. This was not ideal and caused serious performance bottlenecks when calculating portfolio summaries.
 **Action:** Implemented `get_prices_batch` in `server/app/pricing/yahoo_provider.py` using `yfinance.download(symbols_string, period="1d")` to batch requests. Replaced individual fetches in domain services with upfront bulk fetches. When optimizing similar pricing operations, always check if bulk retrieval capabilities exist for the upstream API/provider.
+
+## 2024-05-18 - [Efficient Frontier N+1 Optimization]
+**Learning:** The `efficient_frontier_service` contained an N+1 performance bottleneck similar to other domain services, individually fetching fallback stock prices inside a portfolio symbol loop.
+**Action:** When working on domain services that loop over holdings or symbols, verify whether they call pricing/data-fetching functions directly in the loop. Always use or implement a batch-fetching pattern (`get_prices_batch`) first, taking care to preserve expected short-circuiting logic on failure.

--- a/server/app/domain/services/efficient_frontier_service.py
+++ b/server/app/domain/services/efficient_frontier_service.py
@@ -10,12 +10,19 @@ from scipy.optimize import minimize
 
 from ..repositories import portfolio_repo
 from .portfolio_service import ensure_owner
-from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
+from ...pricing.yahoo_provider import get_historical_prices, get_prices_batch as yahoo_get_prices_batch
 from ...pricing.stub_provider import get_price as stub_get_price
 
 
-def _get_price(symbol: str) -> Decimal:
-    return yahoo_get_price(symbol) or stub_get_price(symbol)
+def _get_prices_batch(symbols: list[str]) -> dict[str, Decimal]:
+    batched_prices = yahoo_get_prices_batch(symbols) if symbols else {}
+    result = {}
+    for symbol in symbols:
+        price = batched_prices.get(symbol.upper())
+        if price is None:
+            price = stub_get_price(symbol)
+        result[symbol] = price
+    return result
 
 
 def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
@@ -71,8 +78,12 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
     # Current portfolio weights
     current_values = {}
     total_value = 0.0
+
+    # ⚡ Bolt: Batch fetch all prices at once instead of N+1 lookups
+    prices = _get_prices_batch(symbols)
+
     for symbol in symbols:
-        price = float(_get_price(symbol))
+        price = float(prices[symbol])
         val = price * quantities[symbol]
         current_values[symbol] = val
         total_value += val


### PR DESCRIPTION
⚡ Bolt: Fix N+1 price fetching in efficient frontier

💡 What: Replaced individual `get_price` calls with a single `get_prices_batch` call within the `_load_portfolio_data` function loop in `efficient_frontier_service`.
🎯 Why: Calling the yahoo pricing provider sequentially for each holding inside a portfolio leads to an N+1 performance bottleneck during frontier calculation.
📊 Impact: Considerably reduces computation latency and network request load (if network requests are active) since prices for all symbols are now retrieved concurrently in one batch.
🔬 Measurement: Verify behavior via backend analytics tests. Ensure `stub_get_price` correctly falls back when Yahoo API fails, preventing regressions.

---
*PR created automatically by Jules for task [17126771650781791368](https://jules.google.com/task/17126771650781791368) started by @chibeze01*