### PR TITLE
⚡ Bolt: [Fix N+1 query problem on historical prices]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-28 - [Backend Yahoo Finance Bulk Download]
 **Learning:** The application was experiencing an N+1 problem in `analytics_service` and `rebalance_service` because `get_price(h.symbol)` was called in a loop for each holding in a portfolio, triggering individual HTTP requests to Yahoo Finance for every ticker. This was not ideal and caused serious performance bottlenecks when calculating portfolio summaries.
 **Action:** Implemented `get_prices_batch` in `server/app/pricing/yahoo_provider.py` using `yfinance.download(symbols_string, period="1d")` to batch requests. Replaced individual fetches in domain services with upfront bulk fetches. When optimizing similar pricing operations, always check if bulk retrieval capabilities exist for the upstream API/provider.
+
+## 2024-04-30 - [Backend Yahoo Finance Historical Bulk Download]
+**Learning:** Found another N+1 bottleneck when fetching historical prices in `analytics_service` and `efficient_frontier_service` because `get_historical_prices` was called in a loop for each symbol.
+**Action:** Implemented `get_historical_prices_batch` in `server/app/pricing/yahoo_provider.py` using `ThreadPoolExecutor` and replaced the loops in both services with this new batch function. Always remember to clean up dirty files like test.db or python patching scripts from the workspace before requesting a code review or committing.

--- a/server/app/domain/services/analytics_service.py
+++ b/server/app/domain/services/analytics_service.py
@@ -46,7 +46,7 @@ def portfolio_pnl(db: Session, user_id: str, portfolio_id: uuid.UUID) -> PnLResp
 
 def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, days: int = 30) -> HistoricalPortfolioResponse:
     """Generate historical portfolio value using real price data from Yahoo Finance."""
-    from ...pricing.yahoo_provider import get_historical_prices, get_prices_batch as yahoo_get_prices_batch
+    from ...pricing.yahoo_provider import get_historical_prices_batch, get_prices_batch as yahoo_get_prices_batch
 
     p = portfolio_repo.get_portfolio(db, portfolio_id)
     ensure_owner(p, user_id)
@@ -71,8 +71,11 @@ def portfolio_historical(db: Session, user_id: str, portfolio_id: uuid.UUID, day
     holding_prices = {}
     current_value = Decimal("0")
 
+    # ⚡ Bolt: Fix N+1 problem by batching historical price fetches
+    historical_prices = get_historical_prices_batch(symbols, days + 5)  # extra days buffer
+
     for h in p.holdings:
-        history = get_historical_prices(h.symbol, days + 5)  # extra days buffer
+        history = historical_prices.get(h.symbol.upper())
         current_price = batched_prices.get(h.symbol) or get_price(h.symbol)
         current_value += current_price * Decimal(str(h.quantity))
 

--- a/server/app/domain/services/efficient_frontier_service.py
+++ b/server/app/domain/services/efficient_frontier_service.py
@@ -10,7 +10,7 @@ from scipy.optimize import minimize
 
 from ..repositories import portfolio_repo
 from .portfolio_service import ensure_owner
-from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price
+from ...pricing.yahoo_provider import get_historical_prices, get_price as yahoo_get_price, get_historical_prices_batch
 from ...pricing.stub_provider import get_price as stub_get_price
 
 
@@ -40,8 +40,12 @@ def _load_portfolio_data(db: Session, user_id: str, portfolio_id: uuid.UUID):
 
     # Fetch historical prices (365 days ≈ 252 trading days for stable estimates)
     returns_matrix = []
+
+    # ⚡ Bolt: Fix N+1 problem by batching historical price fetches
+    historical_prices = get_historical_prices_batch(symbols, 365)
+
     for symbol in symbols:
-        history = get_historical_prices(symbol, 365)
+        history = historical_prices.get(symbol.upper())
         if not history or len(history) < 60:
             raise HTTPException(
                 status_code=400,

--- a/server/app/pricing/yahoo_provider.py
+++ b/server/app/pricing/yahoo_provider.py
@@ -151,6 +151,31 @@ def get_historical_prices(symbol: str, days: int = 30) -> Optional[list[dict]]:
         return None
 
 
+
+def get_historical_prices_batch(symbols: list[str], days: int = 30) -> Dict[str, Optional[list[dict]]]:
+    """
+    Fetch historical prices for multiple symbols efficiently using a thread pool.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    result = {}
+    unique_symbols = list(set(symbols))
+    if not unique_symbols:
+        return result
+
+    with ThreadPoolExecutor(max_workers=min(10, len(unique_symbols))) as executor:
+        future_to_sym = {executor.submit(get_historical_prices, sym, days): sym.upper() for sym in unique_symbols}
+        for future in future_to_sym:
+            sym = future_to_sym[future]
+            try:
+                result[sym] = future.result()
+            except Exception as e:
+                logger.warning(f"Failed to fetch batch historical prices for {sym}: {e}")
+                result[sym] = None
+
+    return result
+
+
 def clear_cache():
     """Clear the price and historical caches."""
     global _price_cache, _historical_cache


### PR DESCRIPTION
💡 What: Implemented `get_historical_prices_batch` in `yahoo_provider.py` utilizing a ThreadPoolExecutor. Updated `efficient_frontier_service.py` and `analytics_service.py` to utilize this bulk fetching mechanism instead of fetching each symbol's history sequentially in a loop.

🎯 Why: To fix an N+1 fetching problem where calculating historical portfolio returns or efficient frontiers caused an I/O wait bottleneck because individual requests were made to Yahoo Finance for each holding.

📊 Impact: Reduces total API response time for historical data fetching in multi-holding portfolios. API calls are now executed in parallel instead of sequentially.

🔬 Measurement: Verifiable by executing portfolio historical analytics queries on multi-asset portfolios and timing the response, or reviewing `yahoo_provider` logs. Tested locally via `pytest` to ensure structural data continuity.

---
*PR created automatically by Jules for task [1699706813535652604](https://jules.google.com/task/1699706813535652604) started by @chibeze01*